### PR TITLE
Fix aud claim check to support array of strings

### DIFF
--- a/consumers/express.js
+++ b/consumers/express.js
@@ -46,7 +46,7 @@ module.exports = (config) => async (req, res, next) => {
   }
 
   var nonce = session && session.nonce
-  var app = config[session.provider].key
+  var app = config[session.provider].key || config[session.provider].client_id
   var error = verify({id_token, jwt, idp, jwk, app, nonce})
 
   if (error) {

--- a/lib/id_token.js
+++ b/lib/id_token.js
@@ -31,7 +31,7 @@ var claims = {
   // audience - is the token intended for me?
   audience: (jwt, app) =>
     // audience - should be your OAuth app ID
-    jwt.payload.aud === app
+    [].concat(jwt.payload.aud).includes(app)
   ,
   // expiration - is the token within its validity window?
   expiration: (jwt) =>


### PR DESCRIPTION
Hi there,

I have a case where the issuer returns `aud` claim as an array of string.
The [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html):

>**aud**  ...In the general case, the aud value is an array of case sensitive strings. In the common special case when there is one audience, the aud value MAY be a single case sensitive string.

I also fixed the case when different `key` fields from https://github.com/simov/grant/blob/master/config/reserved.json are used, eg `key` vs `consumer_key` vs `client_id`

I was trying to follow my general feel of code style since there is no linter ;)

Let me know if ti all make sense or i need to change anything 